### PR TITLE
Use conduit write body trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,8 +250,8 @@ impl<H> hyper::server::Handler for Handler<H>
     }
 }
 
-fn respond<'a>(response: Response<'a, Fresh>, body: &mut Read) -> io::Result<()> {
+fn respond<'a>(response: Response<'a, Fresh>, body: &mut Box<conduit::WriteBody + Send>) -> io::Result<()> {
     let mut response = response.start()?;
-    io::copy(body, &mut response)?;
+    body.write_body(&mut response)?;
     response.end()
 }


### PR DESCRIPTION
I stumbled across this library while playing with `conduit`, and I was interested in trying it out. The current version of conduit on crates.io (`v0.8.1`) now includes the change by which a writer can be passed into `conduit::Response::write_body(...)`.

This is just a tiny patch to implement the corresponding change for`conduit-hyper` so it builds again.